### PR TITLE
feat(ts): docgen / more docstrings

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,6 +43,7 @@ Name|Description
 [PeerDependencyOptions](#projen-peerdependencyoptions)|*No description*
 [ProjectOptions](#projen-projectoptions)|*No description*
 [TypeScriptLibraryProjectOptions](#projen-typescriptlibraryprojectoptions)|*No description*
+[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)|*No description*
 [TypescriptConfigOptions](#projen-typescriptconfigoptions)|*No description*
 
 
@@ -1002,13 +1003,25 @@ new TypeScriptLibraryProject(options: TypeScriptLibraryProjectOptions)
   * **repository** (<code>string</code>)  The repository is the location where the actual code for your package lives. <span style="text-decoration: underline">*Optional*</span>
   * **repositoryDirectory** (<code>string</code>)  If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives. <span style="text-decoration: underline">*Optional*</span>
   * **stability** (<code>string</code>)  Package's Stability. <span style="text-decoration: underline">*Optional*</span>
+  * **docgen** (<code>boolean</code>)  Docgen by Typedoc. <span style="text-decoration: underline">*Default*</span>: false
+  * **docsDirectory** (<code>string</code>)  Docs directory. <span style="text-decoration: underline">*Default*</span>: 'API'
   * **eslint** (<code>boolean</code>)  Setup eslint. <span style="text-decoration: underline">*Default*</span>: true
   * **jest** (<code>boolean</code>)  Setup jest unit tests. <span style="text-decoration: underline">*Default*</span>: true
   * **jestOptions** (<code>[JestOptions](#projen-jestoptions)</code>)  Jest options. <span style="text-decoration: underline">*Default*</span>: default options
   * **mergify** (<code>boolean</code>)  Adds mergify configuration. <span style="text-decoration: underline">*Default*</span>: true
   * **mergifyOptions** (<code>[MergifyOptions](#projen-mergifyoptions)</code>)  Options for mergify. <span style="text-decoration: underline">*Default*</span>: default options
+  * **tsconfigOptions** (<code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code>)  Custom TSConfig. <span style="text-decoration: underline">*Optional*</span>
   * **typescriptVersion** (<code>[Semver](#projen-semver)</code>)  TypeScript version to use. <span style="text-decoration: underline">*Default*</span>: ^3.9.5
 
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**docsDirectory**🔹 | <code>string</code> | <span></span>
+**docgen**?🔹 | <code>boolean</code> | <span style="text-decoration: underline">*Optional*</span>
 
 
 
@@ -1027,13 +1040,13 @@ new TypeScriptLibraryProject(options: TypeScriptLibraryProjectOptions)
 <span style="text-decoration: underline">Usage:</span>
 
 ```ts
-new TypescriptConfig(project: NodeProject, options?: TypescriptConfigOptions)
+new TypescriptConfig(project: NodeProject, options: TypescriptConfigOptions)
 ```
 
 <span style="text-decoration: underline">Parameters:</span>
 * **project** (<code>[NodeProject](#projen-nodeproject)</code>)  *No description*
 * **options** (<code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code>)  *No description*
-  * **compilerOptions** (<code>any</code>)  Compiler options to use. <span style="text-decoration: underline">*Default*</span>: see above
+  * **compilerOptions** (<code>[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)</code>)  Compiler options to use. 
   * **exclude** (<code>Array<string></code>)  *No description* <span style="text-decoration: underline">*Default*</span>: node_modules is excluded by default
   * **fileName** (<code>string</code>)  *No description* <span style="text-decoration: underline">*Default*</span>: "tsconfig.json"
   * **include** (<code>Array<string></code>)  The directory in which typescript sources reside. <span style="text-decoration: underline">*Default*</span>: all .ts files recursively
@@ -1045,7 +1058,7 @@ new TypescriptConfig(project: NodeProject, options?: TypescriptConfigOptions)
 
 Name | Type | Description 
 -----|------|-------------
-**compilerOptions**🔹 | <code>any</code> | <span></span>
+**compilerOptions**🔹 | <code>[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)</code> | <span></span>
 **exclude**🔹 | <code>Array<string></code> | <span></span>
 **fileName**🔹 | <code>string</code> | <span></span>
 **include**🔹 | <code>Array<string></code> | <span></span>
@@ -1441,6 +1454,8 @@ Name | Type | Description
 **dependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
 **description**?🔹 | <code>string</code> | The description is just a string that helps people understand the purpose of the package.<br/><span style="text-decoration: underline">*Optional*</span>
 **devDependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
+**docgen**?🔹 | <code>boolean</code> | Docgen by Typedoc.<br/><span style="text-decoration: underline">*Default*</span>: false
+**docsDirectory**?🔹 | <code>string</code> | Docs directory.<br/><span style="text-decoration: underline">*Default*</span>: 'API'
 **eslint**?🔹 | <code>boolean</code> | Setup eslint.<br/><span style="text-decoration: underline">*Default*</span>: true
 **gitignore**?🔹 | <code>Array<string></code> | Additional entries to .gitignore.<br/><span style="text-decoration: underline">*Optional*</span>
 **homepage**?🔹 | <code>string</code> | Package's Homepage / Website.<br/><span style="text-decoration: underline">*Optional*</span>
@@ -1465,10 +1480,45 @@ Name | Type | Description
 **repository**?🔹 | <code>string</code> | The repository is the location where the actual code for your package lives.<br/><span style="text-decoration: underline">*Optional*</span>
 **repositoryDirectory**?🔹 | <code>string</code> | If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives.<br/><span style="text-decoration: underline">*Optional*</span>
 **stability**?🔹 | <code>string</code> | Package's Stability.<br/><span style="text-decoration: underline">*Optional*</span>
+**tsconfigOptions**?🔹 | <code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code> | Custom TSConfig.<br/><span style="text-decoration: underline">*Optional*</span>
 **typescriptVersion**?🔹 | <code>[Semver](#projen-semver)</code> | TypeScript version to use.<br/><span style="text-decoration: underline">*Default*</span>: ^3.9.5
 **workflowBootstrapSteps**?🔹 | <code>Array<any></code> | Workflow steps to use in order to bootstrap this repo.<br/><span style="text-decoration: underline">*Default*</span>: [ { run: `npx projen${PROJEN_VERSION}` }, { run: 'yarn install --frozen-lockfile' } ]
 **workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/><span style="text-decoration: underline">*Default*</span>: default image
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/><span style="text-decoration: underline">*Default*</span>: same as `minNodeVersion`
+
+
+
+## struct TypescriptConfigCompilerOptions 🔹 <a id="projen-typescriptconfigcompileroptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**alwaysStrict**?🔹 | <code>boolean</code> | Ensures that your files are parsed in the ECMAScript strict mode, and emit “use strict” for each source file.<br/><span style="text-decoration: underline">*Default*</span>: true
+**declaration**?🔹 | <code>boolean</code> | To be specified along with the above.<br/><span style="text-decoration: underline">*Optional*</span>
+**declarationDir**?🔹 | <code>string</code> | Offers a way to configure the root directory for where declaration files are emitted.<br/><span style="text-decoration: underline">*Optional*</span>
+**experimentalDecorators**?🔹 | <code>boolean</code> | Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.<br/><span style="text-decoration: underline">*Default*</span>: true
+**inlineSourceMap**?🔹 | <code>boolean</code> | When set, instead of writing out a .js.map file to provide source maps,  TypeScript will embed the source map content in the .js files.<br/><span style="text-decoration: underline">*Default*</span>: true
+**inlineSources**?🔹 | <code>boolean</code> | When set, TypeScript will include the original content of the .ts file as an embedded  string in the source map. This is often useful in the same cases as inlineSourceMap.<br/><span style="text-decoration: underline">*Default*</span>: true
+**lib**?🔹 | <code>Array<string></code> | Reference for type definitions / libraries to use (eg.<br/><span style="text-decoration: underline">*Default*</span>: [ 'es2018' ]
+**module**?🔹 | <code>string</code> | Sets the module system for the program.<br/><span style="text-decoration: underline">*Default*</span>: 'CommonJS'
+**noEmitOnError**?🔹 | <code>boolean</code> | Do not emit compiler output files like JavaScript source code, source-maps or declarations if any errors were reported.<br/><span style="text-decoration: underline">*Default*</span>: true
+**noFallthroughCasesInSwitch**?🔹 | <code>boolean</code> | Report errors for fallthrough cases in switch statements.<br/><span style="text-decoration: underline">*Default*</span>: true
+**noImplicitAny**?🔹 | <code>boolean</code> | In some cases where no type annotations are present, TypeScript will fall back to a type of any for a variable when it cannot infer the type.<br/><span style="text-decoration: underline">*Default*</span>: true
+**noImplicitReturns**?🔹 | <code>boolean</code> | When enabled, TypeScript will check all code paths in a function to ensure they  return a value.<br/><span style="text-decoration: underline">*Default*</span>: true
+**noImplicitThis**?🔹 | <code>boolean</code> | Raise error on ‘this’ expressions with an implied ‘any’ type.<br/><span style="text-decoration: underline">*Default*</span>: true
+**noUnusedLocals**?🔹 | <code>boolean</code> | Report errors on unused local variables.<br/><span style="text-decoration: underline">*Default*</span>: true
+**noUnusedParameters**?🔹 | <code>boolean</code> | Report errors on unused parameters in functions.<br/><span style="text-decoration: underline">*Default*</span>: true
+**outDir**?🔹 | <code>string</code> | Output directory for the compiled files.<br/><span style="text-decoration: underline">*Optional*</span>
+**resolveJsonModule**?🔹 | <code>boolean</code> | Allows importing modules with a ‘.json’ extension, which is a common practice  in node projects. This includes generating a type for the import based on the static JSON shape.<br/><span style="text-decoration: underline">*Default*</span>: true
+**strict**?🔹 | <code>boolean</code> | The strict flag enables a wide range of type checking behavior that results in stronger guarantees  of program correctness.<br/><span style="text-decoration: underline">*Default*</span>: true
+**strictNullChecks**?🔹 | <code>boolean</code> | When strictNullChecks is false, null and undefined are effectively ignored by the language.<br/><span style="text-decoration: underline">*Default*</span>: true
+**strictPropertyInitialization**?🔹 | <code>boolean</code> | When set to true, TypeScript will raise an error when a class property was declared but  not set in the constructor.<br/><span style="text-decoration: underline">*Default*</span>: true
+**stripInternal**?🔹 | <code>boolean</code> | Do not emit declarations for code that has an @internal annotation in it’s JSDoc comment.<br/><span style="text-decoration: underline">*Default*</span>: true
+**target**?🔹 | <code>string</code> | Modern browsers support all ES6 features, so ES6 is a good choice.<br/><span style="text-decoration: underline">*Default*</span>: 'ES2018'
 
 
 
@@ -1481,7 +1531,7 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**compilerOptions**?🔹 | <code>any</code> | Compiler options to use.<br/><span style="text-decoration: underline">*Default*</span>: see above
+**compilerOptions**🔹 | <code>[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)</code> | Compiler options to use.
 **exclude**?🔹 | <code>Array<string></code> | <span style="text-decoration: underline">*Default*</span>: node_modules is excluded by default
 **fileName**?🔹 | <code>string</code> | <span style="text-decoration: underline">*Default*</span>: "tsconfig.json"
 **include**?🔹 | <code>Array<string></code> | The directory in which typescript sources reside.<br/><span style="text-decoration: underline">*Default*</span>: all .ts files recursively

--- a/API.md
+++ b/API.md
@@ -42,8 +42,8 @@ Name|Description
 [NodeProjectOptions](#projen-nodeprojectoptions)|*No description*
 [PeerDependencyOptions](#projen-peerdependencyoptions)|*No description*
 [ProjectOptions](#projen-projectoptions)|*No description*
+[TypeScriptCompilerOptions](#projen-typescriptcompileroptions)|*No description*
 [TypeScriptLibraryProjectOptions](#projen-typescriptlibraryprojectoptions)|*No description*
-[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)|*No description*
 [TypescriptConfigOptions](#projen-typescriptconfigoptions)|*No description*
 
 
@@ -1004,13 +1004,13 @@ new TypeScriptLibraryProject(options: TypeScriptLibraryProjectOptions)
   * **repositoryDirectory** (<code>string</code>)  If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives. <span style="text-decoration: underline">*Optional*</span>
   * **stability** (<code>string</code>)  Package's Stability. <span style="text-decoration: underline">*Optional*</span>
   * **docgen** (<code>boolean</code>)  Docgen by Typedoc. <span style="text-decoration: underline">*Default*</span>: false
-  * **docsDirectory** (<code>string</code>)  Docs directory. <span style="text-decoration: underline">*Default*</span>: 'API'
+  * **docsDirectory** (<code>string</code>)  Docs directory. <span style="text-decoration: underline">*Default*</span>: 'docs'
   * **eslint** (<code>boolean</code>)  Setup eslint. <span style="text-decoration: underline">*Default*</span>: true
   * **jest** (<code>boolean</code>)  Setup jest unit tests. <span style="text-decoration: underline">*Default*</span>: true
   * **jestOptions** (<code>[JestOptions](#projen-jestoptions)</code>)  Jest options. <span style="text-decoration: underline">*Default*</span>: default options
   * **mergify** (<code>boolean</code>)  Adds mergify configuration. <span style="text-decoration: underline">*Default*</span>: true
   * **mergifyOptions** (<code>[MergifyOptions](#projen-mergifyoptions)</code>)  Options for mergify. <span style="text-decoration: underline">*Default*</span>: default options
-  * **tsconfigOptions** (<code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code>)  Custom TSConfig. <span style="text-decoration: underline">*Optional*</span>
+  * **tsconfig** (<code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code>)  Custom TSConfig. <span style="text-decoration: underline">*Optional*</span>
   * **typescriptVersion** (<code>[Semver](#projen-semver)</code>)  TypeScript version to use. <span style="text-decoration: underline">*Default*</span>: ^3.9.5
 
 
@@ -1046,7 +1046,7 @@ new TypescriptConfig(project: NodeProject, options: TypescriptConfigOptions)
 <span style="text-decoration: underline">Parameters:</span>
 * **project** (<code>[NodeProject](#projen-nodeproject)</code>)  *No description*
 * **options** (<code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code>)  *No description*
-  * **compilerOptions** (<code>[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)</code>)  Compiler options to use. 
+  * **compilerOptions** (<code>[TypeScriptCompilerOptions](#projen-typescriptcompileroptions)</code>)  Compiler options to use. 
   * **exclude** (<code>Array<string></code>)  *No description* <span style="text-decoration: underline">*Default*</span>: node_modules is excluded by default
   * **fileName** (<code>string</code>)  *No description* <span style="text-decoration: underline">*Default*</span>: "tsconfig.json"
   * **include** (<code>Array<string></code>)  The directory in which typescript sources reside. <span style="text-decoration: underline">*Default*</span>: all .ts files recursively
@@ -1058,7 +1058,7 @@ new TypescriptConfig(project: NodeProject, options: TypescriptConfigOptions)
 
 Name | Type | Description 
 -----|------|-------------
-**compilerOptions**🔹 | <code>[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)</code> | <span></span>
+**compilerOptions**🔹 | <code>[TypeScriptCompilerOptions](#projen-typescriptcompileroptions)</code> | <span></span>
 **exclude**🔹 | <code>Array<string></code> | <span></span>
 **fileName**🔹 | <code>string</code> | <span></span>
 **include**🔹 | <code>Array<string></code> | <span></span>
@@ -1430,65 +1430,7 @@ Name | Type | Description
 
 
 
-## struct TypeScriptLibraryProjectOptions 🔹 <a id="projen-typescriptlibraryprojectoptions"></a>
-
-
-
-
-
-
-Name | Type | Description 
------|------|-------------
-**name**🔹 | <code>string</code> | This is the name of your package.
-**antitamper**?🔹 | <code>boolean</code> | Checks that after build there are no modified files onn git.<br/><span style="text-decoration: underline">*Default*</span>: true
-**authorEmail**?🔹 | <code>string</code> | Author's e-mail.<br/><span style="text-decoration: underline">*Optional*</span>
-**authorName**?🔹 | <code>string</code> | Author's name.<br/><span style="text-decoration: underline">*Optional*</span>
-**authorOrganization**?🔹 | <code>boolean</code> | Author's Organization.<br/><span style="text-decoration: underline">*Optional*</span>
-**authorUrl**?🔹 | <code>string</code> | Author's URL / Website.<br/><span style="text-decoration: underline">*Optional*</span>
-**autoDetectBin**?🔹 | <code>boolean</code> | Automatically add all executables under the `bin` directory to your `package.json` file under the `bin` section.<br/><span style="text-decoration: underline">*Default*</span>: true
-**bin**?🔹 | <code>Map<string, string></code> | Binary programs vended with your module.<br/><span style="text-decoration: underline">*Optional*</span>
-**buildWorkflow**?🔹 | <code>boolean</code> | Define a GitHub workflow for building PRs.<br/><span style="text-decoration: underline">*Default*</span>: true
-**bundledDependencies**?🔹 | <code>Array<string></code> | <span style="text-decoration: underline">*Optional*</span>
-**copyrightOwner**?🔹 | <code>string</code> | License copyright owner.<br/><span style="text-decoration: underline">*Default*</span>: defaults to the value of authorName or "" if `authorName` is undefined.
-**copyrightPeriod**?🔹 | <code>string</code> | The copyright years to put in the LICENSE file.<br/><span style="text-decoration: underline">*Default*</span>: current year
-**dependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
-**description**?🔹 | <code>string</code> | The description is just a string that helps people understand the purpose of the package.<br/><span style="text-decoration: underline">*Optional*</span>
-**devDependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
-**docgen**?🔹 | <code>boolean</code> | Docgen by Typedoc.<br/><span style="text-decoration: underline">*Default*</span>: false
-**docsDirectory**?🔹 | <code>string</code> | Docs directory.<br/><span style="text-decoration: underline">*Default*</span>: 'API'
-**eslint**?🔹 | <code>boolean</code> | Setup eslint.<br/><span style="text-decoration: underline">*Default*</span>: true
-**gitignore**?🔹 | <code>Array<string></code> | Additional entries to .gitignore.<br/><span style="text-decoration: underline">*Optional*</span>
-**homepage**?🔹 | <code>string</code> | Package's Homepage / Website.<br/><span style="text-decoration: underline">*Optional*</span>
-**jest**?🔹 | <code>boolean</code> | Setup jest unit tests.<br/><span style="text-decoration: underline">*Default*</span>: true
-**jestOptions**?🔹 | <code>[JestOptions](#projen-jestoptions)</code> | Jest options.<br/><span style="text-decoration: underline">*Default*</span>: default options
-**keywords**?🔹 | <code>Array<string></code> | <span style="text-decoration: underline">*Optional*</span>
-**license**?🔹 | <code>string</code> | License's SPDX identifier.<br/><span style="text-decoration: underline">*Optional*</span>
-**maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/><span style="text-decoration: underline">*Default*</span>: no max
-**mergify**?🔹 | <code>boolean</code> | Adds mergify configuration.<br/><span style="text-decoration: underline">*Default*</span>: true
-**mergifyOptions**?🔹 | <code>[MergifyOptions](#projen-mergifyoptions)</code> | Options for mergify.<br/><span style="text-decoration: underline">*Default*</span>: default options
-**minNodeVersion**?🔹 | <code>string</code> | Node.js version to require via package.json `engines` (inclusive).<br/><span style="text-decoration: underline">*Default*</span>: no "engines" specified
-**npmDistTag**?🔹 | <code>string</code> | The dist-tag to use when releasing to npm.<br/><span style="text-decoration: underline">*Default*</span>: "latest"
-**npmignore**?🔹 | <code>Array<string></code> | Additional entries to .npmignore.<br/><span style="text-decoration: underline">*Optional*</span>
-**outdir**?🔹 | <code>string</code> | Where to put the generated project files.<br/><span style="text-decoration: underline">*Default*</span>: . current directory
-**peerDependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
-**peerDependencyOptions**?🔹 | <code>[PeerDependencyOptions](#projen-peerdependencyoptions)</code> | <span style="text-decoration: underline">*Optional*</span>
-**projenDevDependency**?🔹 | <code>boolean</code> | Indicates of "projen" should be installed as a devDependency.<br/><span style="text-decoration: underline">*Default*</span>: true
-**projenVersion**?🔹 | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/><span style="text-decoration: underline">*Default*</span>: latest version
-**releaseBranches**?🔹 | <code>Array<string></code> | Branches which trigger a release.<br/><span style="text-decoration: underline">*Default*</span>: [ "master" ]
-**releaseToNpm**?🔹 | <code>boolean</code> | Automatically release to npm when new versions are introduced.<br/><span style="text-decoration: underline">*Default*</span>: true
-**releaseWorkflow**?🔹 | <code>boolean</code> | Define a GitHub workflow for releasing from "master" when new versions are bumped.<br/><span style="text-decoration: underline">*Default*</span>: true
-**repository**?🔹 | <code>string</code> | The repository is the location where the actual code for your package lives.<br/><span style="text-decoration: underline">*Optional*</span>
-**repositoryDirectory**?🔹 | <code>string</code> | If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives.<br/><span style="text-decoration: underline">*Optional*</span>
-**stability**?🔹 | <code>string</code> | Package's Stability.<br/><span style="text-decoration: underline">*Optional*</span>
-**tsconfigOptions**?🔹 | <code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code> | Custom TSConfig.<br/><span style="text-decoration: underline">*Optional*</span>
-**typescriptVersion**?🔹 | <code>[Semver](#projen-semver)</code> | TypeScript version to use.<br/><span style="text-decoration: underline">*Default*</span>: ^3.9.5
-**workflowBootstrapSteps**?🔹 | <code>Array<any></code> | Workflow steps to use in order to bootstrap this repo.<br/><span style="text-decoration: underline">*Default*</span>: [ { run: `npx projen${PROJEN_VERSION}` }, { run: 'yarn install --frozen-lockfile' } ]
-**workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/><span style="text-decoration: underline">*Default*</span>: default image
-**workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/><span style="text-decoration: underline">*Default*</span>: same as `minNodeVersion`
-
-
-
-## struct TypescriptConfigCompilerOptions 🔹 <a id="projen-typescriptconfigcompileroptions"></a>
+## struct TypeScriptCompilerOptions 🔹 <a id="projen-typescriptcompileroptions"></a>
 
 
 
@@ -1522,6 +1464,64 @@ Name | Type | Description
 
 
 
+## struct TypeScriptLibraryProjectOptions 🔹 <a id="projen-typescriptlibraryprojectoptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**name**🔹 | <code>string</code> | This is the name of your package.
+**antitamper**?🔹 | <code>boolean</code> | Checks that after build there are no modified files onn git.<br/><span style="text-decoration: underline">*Default*</span>: true
+**authorEmail**?🔹 | <code>string</code> | Author's e-mail.<br/><span style="text-decoration: underline">*Optional*</span>
+**authorName**?🔹 | <code>string</code> | Author's name.<br/><span style="text-decoration: underline">*Optional*</span>
+**authorOrganization**?🔹 | <code>boolean</code> | Author's Organization.<br/><span style="text-decoration: underline">*Optional*</span>
+**authorUrl**?🔹 | <code>string</code> | Author's URL / Website.<br/><span style="text-decoration: underline">*Optional*</span>
+**autoDetectBin**?🔹 | <code>boolean</code> | Automatically add all executables under the `bin` directory to your `package.json` file under the `bin` section.<br/><span style="text-decoration: underline">*Default*</span>: true
+**bin**?🔹 | <code>Map<string, string></code> | Binary programs vended with your module.<br/><span style="text-decoration: underline">*Optional*</span>
+**buildWorkflow**?🔹 | <code>boolean</code> | Define a GitHub workflow for building PRs.<br/><span style="text-decoration: underline">*Default*</span>: true
+**bundledDependencies**?🔹 | <code>Array<string></code> | <span style="text-decoration: underline">*Optional*</span>
+**copyrightOwner**?🔹 | <code>string</code> | License copyright owner.<br/><span style="text-decoration: underline">*Default*</span>: defaults to the value of authorName or "" if `authorName` is undefined.
+**copyrightPeriod**?🔹 | <code>string</code> | The copyright years to put in the LICENSE file.<br/><span style="text-decoration: underline">*Default*</span>: current year
+**dependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
+**description**?🔹 | <code>string</code> | The description is just a string that helps people understand the purpose of the package.<br/><span style="text-decoration: underline">*Optional*</span>
+**devDependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
+**docgen**?🔹 | <code>boolean</code> | Docgen by Typedoc.<br/><span style="text-decoration: underline">*Default*</span>: false
+**docsDirectory**?🔹 | <code>string</code> | Docs directory.<br/><span style="text-decoration: underline">*Default*</span>: 'docs'
+**eslint**?🔹 | <code>boolean</code> | Setup eslint.<br/><span style="text-decoration: underline">*Default*</span>: true
+**gitignore**?🔹 | <code>Array<string></code> | Additional entries to .gitignore.<br/><span style="text-decoration: underline">*Optional*</span>
+**homepage**?🔹 | <code>string</code> | Package's Homepage / Website.<br/><span style="text-decoration: underline">*Optional*</span>
+**jest**?🔹 | <code>boolean</code> | Setup jest unit tests.<br/><span style="text-decoration: underline">*Default*</span>: true
+**jestOptions**?🔹 | <code>[JestOptions](#projen-jestoptions)</code> | Jest options.<br/><span style="text-decoration: underline">*Default*</span>: default options
+**keywords**?🔹 | <code>Array<string></code> | <span style="text-decoration: underline">*Optional*</span>
+**license**?🔹 | <code>string</code> | License's SPDX identifier.<br/><span style="text-decoration: underline">*Optional*</span>
+**maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/><span style="text-decoration: underline">*Default*</span>: no max
+**mergify**?🔹 | <code>boolean</code> | Adds mergify configuration.<br/><span style="text-decoration: underline">*Default*</span>: true
+**mergifyOptions**?🔹 | <code>[MergifyOptions](#projen-mergifyoptions)</code> | Options for mergify.<br/><span style="text-decoration: underline">*Default*</span>: default options
+**minNodeVersion**?🔹 | <code>string</code> | Node.js version to require via package.json `engines` (inclusive).<br/><span style="text-decoration: underline">*Default*</span>: no "engines" specified
+**npmDistTag**?🔹 | <code>string</code> | The dist-tag to use when releasing to npm.<br/><span style="text-decoration: underline">*Default*</span>: "latest"
+**npmignore**?🔹 | <code>Array<string></code> | Additional entries to .npmignore.<br/><span style="text-decoration: underline">*Optional*</span>
+**outdir**?🔹 | <code>string</code> | Where to put the generated project files.<br/><span style="text-decoration: underline">*Default*</span>: . current directory
+**peerDependencies**?🔹 | <code>Map<string, [Semver](#projen-semver)></code> | <span style="text-decoration: underline">*Optional*</span>
+**peerDependencyOptions**?🔹 | <code>[PeerDependencyOptions](#projen-peerdependencyoptions)</code> | <span style="text-decoration: underline">*Optional*</span>
+**projenDevDependency**?🔹 | <code>boolean</code> | Indicates of "projen" should be installed as a devDependency.<br/><span style="text-decoration: underline">*Default*</span>: true
+**projenVersion**?🔹 | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/><span style="text-decoration: underline">*Default*</span>: latest version
+**releaseBranches**?🔹 | <code>Array<string></code> | Branches which trigger a release.<br/><span style="text-decoration: underline">*Default*</span>: [ "master" ]
+**releaseToNpm**?🔹 | <code>boolean</code> | Automatically release to npm when new versions are introduced.<br/><span style="text-decoration: underline">*Default*</span>: true
+**releaseWorkflow**?🔹 | <code>boolean</code> | Define a GitHub workflow for releasing from "master" when new versions are bumped.<br/><span style="text-decoration: underline">*Default*</span>: true
+**repository**?🔹 | <code>string</code> | The repository is the location where the actual code for your package lives.<br/><span style="text-decoration: underline">*Optional*</span>
+**repositoryDirectory**?🔹 | <code>string</code> | If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives.<br/><span style="text-decoration: underline">*Optional*</span>
+**stability**?🔹 | <code>string</code> | Package's Stability.<br/><span style="text-decoration: underline">*Optional*</span>
+**tsconfig**?🔹 | <code>[TypescriptConfigOptions](#projen-typescriptconfigoptions)</code> | Custom TSConfig.<br/><span style="text-decoration: underline">*Optional*</span>
+**typescriptVersion**?🔹 | <code>[Semver](#projen-semver)</code> | TypeScript version to use.<br/><span style="text-decoration: underline">*Default*</span>: ^3.9.5
+**workflowBootstrapSteps**?🔹 | <code>Array<any></code> | Workflow steps to use in order to bootstrap this repo.<br/><span style="text-decoration: underline">*Default*</span>: [ { run: `npx projen${PROJEN_VERSION}` }, { run: 'yarn install --frozen-lockfile' } ]
+**workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/><span style="text-decoration: underline">*Default*</span>: default image
+**workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/><span style="text-decoration: underline">*Default*</span>: same as `minNodeVersion`
+
+
+
 ## struct TypescriptConfigOptions 🔹 <a id="projen-typescriptconfigoptions"></a>
 
 
@@ -1531,7 +1531,7 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**compilerOptions**🔹 | <code>[TypescriptConfigCompilerOptions](#projen-typescriptconfigcompileroptions)</code> | Compiler options to use.
+**compilerOptions**🔹 | <code>[TypeScriptCompilerOptions](#projen-typescriptcompileroptions)</code> | Compiler options to use.
 **exclude**?🔹 | <code>Array<string></code> | <span style="text-decoration: underline">*Default*</span>: node_modules is excluded by default
 **fileName**?🔹 | <code>string</code> | <span style="text-decoration: underline">*Default*</span>: "tsconfig.json"
 **include**?🔹 | <code>Array<string></code> | The directory in which typescript sources reside.<br/><span style="text-decoration: underline">*Default*</span>: all .ts files recursively

--- a/src/jsii-project.ts
+++ b/src/jsii-project.ts
@@ -284,6 +284,28 @@ export class JsiiProject extends NodeProject {
         exclude: [
           'node_modules',
         ],
+        compilerOptions: {
+          alwaysStrict: true,
+          declaration: true,
+          experimentalDecorators: true,
+          inlineSourceMap: true,
+          inlineSources: true,
+          lib: [ 'es2018' ],
+          module: 'CommonJS',
+          noEmitOnError: true,
+          noFallthroughCasesInSwitch: true,
+          noImplicitAny: true,
+          noImplicitReturns: true,
+          noImplicitThis: true,
+          noUnusedLocals: true,
+          noUnusedParameters: true,
+          resolveJsonModule: true,
+          strict: true,
+          strictNullChecks: true,
+          strictPropertyInitialization: true,
+          stripInternal: true,
+          target: 'ES2018',
+        },
       });
 
       // make sure to delete "lib" *before* runninng tests to ensure that

--- a/src/typescript-typedoc.ts
+++ b/src/typescript-typedoc.ts
@@ -1,0 +1,17 @@
+import { Construct } from 'constructs';
+import { TypeScriptLibraryProject } from './typescript';
+import { Semver } from './semver';
+
+/**
+  Adds a simple Typescript documentation generator
+ */
+export class TypedocDocgen extends Construct {
+  constructor(project: TypeScriptLibraryProject) {
+    super(project, 'typedoc');
+
+    project.addDevDependencies({ typedoc: Semver.caret('0.17.8') });
+    project.addScripts({
+      docgen: 'typedoc --out ' + project.docsDirectory,
+    }); 
+  }
+}

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -5,6 +5,7 @@ import { Eslint } from './eslint';
 import { Semver } from './semver';
 import { Mergify, MergifyOptions } from './mergify';
 import { Construct } from 'constructs';
+import { TypedocDocgen } from './typescript-typedoc';
 
 export interface TypeScriptLibraryProjectOptions extends NodeProjectOptions {
   /**
@@ -43,11 +44,37 @@ export interface TypeScriptLibraryProjectOptions extends NodeProjectOptions {
    * @default - default options
    */
   readonly mergifyOptions?: MergifyOptions;
+
+  /**
+   * Docgen by Typedoc
+   * 
+   * @default false
+   */
+  readonly docgen?: boolean;
+
+  /**
+   * Docs directory
+   * 
+   * @default 'API'
+   */
+  readonly docsDirectory?: string;
+
+  /**
+   * Custom TSConfig
+   * 
+   */
+  readonly tsconfigOptions?: TypescriptConfigOptions;
 }
 
 export class TypeScriptLibraryProject extends NodeProject {
+  public readonly docgen?: boolean;
+  public readonly docsDirectory: string;
+
   constructor(options: TypeScriptLibraryProjectOptions) {
     super(options);
+    
+    this.docgen = options.docgen;
+    this.docsDirectory = options.docsDirectory || 'API/';
 
     this.addScripts({
       compile: 'tsc',
@@ -59,6 +86,29 @@ export class TypeScriptLibraryProject extends NodeProject {
     const tsconfig = new TypescriptConfig(this, {
       include: [ '**/*.ts' ],
       exclude: [ 'node_modules' ],
+      compilerOptions: {
+        alwaysStrict: true,
+        declaration: true,
+        experimentalDecorators: true,
+        inlineSourceMap: true,
+        inlineSources: true,
+        lib: [ 'es2018' ],
+        module: 'CommonJS',
+        noEmitOnError: true,
+        noFallthroughCasesInSwitch: true,
+        noImplicitAny: true,
+        noImplicitReturns: true,
+        noImplicitThis: true,
+        noUnusedLocals: true,
+        noUnusedParameters: true,
+        resolveJsonModule: true,
+        strict: true,
+        strictNullChecks: true,
+        strictPropertyInitialization: true,
+        stripInternal: true,
+        target: 'ES2018',
+      },
+      ...options.tsconfigOptions,
     });
 
     this.gitignore.comment('exclude typescript compiler outputs');
@@ -91,6 +141,10 @@ export class TypeScriptLibraryProject extends NodeProject {
     if (options.mergify ?? true) {
       new Mergify(this, options.mergifyOptions);
     }
+
+    if (this.docgen) {
+      new TypedocDocgen(this);
+    }
   }
 }
 
@@ -115,16 +169,186 @@ export interface TypescriptConfigOptions {
    *
    * @default - see above
    */
-  readonly compilerOptions?: any;
+  readonly compilerOptions: TypescriptConfigCompilerOptions;
+}
+
+export interface TypescriptConfigCompilerOptions {
+  /**
+   * Ensures that your files are parsed in the ECMAScript strict mode, and emit “use strict”
+   * for each source file.
+   * 
+   * @default true
+   */
+  readonly alwaysStrict?: boolean;
+  
+  /**
+   * Offers a way to configure the root directory for where declaration files are emitted.
+   * 
+   */
+  readonly declarationDir?: string;
+
+  /**
+   * To be specified along with the above
+   * 
+   */
+  readonly declaration?: boolean;
+  
+  /**
+   * Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.
+   * 
+   * @default true
+   */
+  readonly experimentalDecorators?: boolean; 
+  
+  /**
+   * When set, instead of writing out a .js.map file to provide source maps, 
+   * TypeScript will embed the source map content in the .js files.  
+   *
+   * @default true
+   */
+  readonly inlineSourceMap?: boolean;
+
+  /**
+   * When set, TypeScript will include the original content of the .ts file as an embedded 
+   * string in the source map. This is often useful in the same cases as inlineSourceMap.
+   *
+   * @default true
+   */
+  readonly inlineSources?: boolean;
+
+  /**
+   * Reference for type definitions / libraries to use (eg. ES2016, ES5, ES2018).
+   *
+   * @default [ 'es2018' ]
+   */
+  readonly lib?: string[];
+
+  /**
+   * Sets the module system for the program. 
+   * See https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules.
+   *
+   * @default 'CommonJS'
+   */
+  readonly module?: string;
+  
+  /**
+   * Do not emit compiler output files like JavaScript source code, source-maps or
+   * declarations if any errors were reported.
+   *
+   * @default true
+   */
+  readonly noEmitOnError?: boolean;
+  
+  /**
+   * Report errors for fallthrough cases in switch statements. Ensures that any non-empty 
+   * case inside a switch statement includes either break or return. This means you won’t 
+   * accidentally ship a case fallthrough bug.
+   *
+   * @default true
+   */
+  readonly noFallthroughCasesInSwitch?: boolean;
+
+  /**
+   * In some cases where no type annotations are present, TypeScript will fall back to a
+   * type of any for a variable when it cannot infer the type.
+   *
+   * @default true
+   */
+  readonly noImplicitAny?: boolean;
+  
+  /**
+   * When enabled, TypeScript will check all code paths in a function to ensure they 
+   * return a value.
+   * 
+   * @default true
+   */
+  readonly noImplicitReturns?: boolean;
+  /**
+   * Raise error on ‘this’ expressions with an implied ‘any’ type.
+   * 
+   * @default true
+   */
+  readonly noImplicitThis?: boolean;
+
+  /**
+   * Report errors on unused local variables.
+   * 
+   * @default true
+   */
+  readonly noUnusedLocals?: boolean;
+  
+  /**
+   * Report errors on unused parameters in functions.
+   * 
+   * @default true
+   */
+  readonly noUnusedParameters?: boolean;
+
+  /**
+   * Allows importing modules with a ‘.json’ extension, which is a common practice 
+   * in node projects. This includes generating a type for the import based on the static JSON shape.
+   * 
+   * @default true
+   */
+  readonly resolveJsonModule?: boolean;
+
+  /**
+   * The strict flag enables a wide range of type checking behavior that results in stronger guarantees 
+   * of program correctness. Turning this on is equivalent to enabling all of the strict mode family 
+   * options, which are outlined below. You can then turn off individual strict mode family checks as
+   * needed.
+   * 
+   * @default true  
+   */
+  readonly strict?: boolean;
+
+  /**
+   * When strictNullChecks is false, null and undefined are effectively ignored by the language. 
+   * This can lead to unexpected errors at runtime.
+   * When strictNullChecks is true, null and undefined have their own distinct types and you’ll 
+   * get a type error if you try to use them where a concrete value is expected.
+   * 
+   * @default true
+   */  
+  readonly strictNullChecks?: boolean;
+  
+  /**
+   * When set to true, TypeScript will raise an error when a class property was declared but 
+   * not set in the constructor. 
+   * 
+   * @default true
+   */
+  readonly strictPropertyInitialization?: boolean;
+
+  /**
+   * Do not emit declarations for code that has an @internal annotation in it’s JSDoc comment.
+   * 
+   * @default true
+   */
+  readonly stripInternal?: boolean;
+
+  /**
+   * Modern browsers support all ES6 features, so ES6 is a good choice. You might choose to set
+   * a lower target if your code is deployed to older environments, or a higher target if your
+   * code is guaranteed to run in newer environments.
+   * 
+   * @default 'ES2018'
+   */
+  readonly target?: string;
+
+  /**
+   * Output directory for the compiled files.
+   */
+  readonly outDir?: string;
 }
 
 export class TypescriptConfig extends Construct {
-  public readonly compilerOptions: any;
+  public readonly compilerOptions: TypescriptConfigCompilerOptions;
   public readonly include: string[];
   public readonly exclude: string[];
   public readonly fileName: string;
 
-  constructor(project: NodeProject, options: TypescriptConfigOptions = { }) {
+  constructor(project: NodeProject, options: TypescriptConfigOptions) {
     const fileName = options.fileName ?? 'tsconfig.json';
 
     super(project, `tsconfig-${fileName}`);
@@ -133,30 +357,7 @@ export class TypescriptConfig extends Construct {
     this.exclude = options.exclude ?? [ 'node_modules' ];
     this.fileName = fileName;
 
-    this.compilerOptions = {
-      alwaysStrict: true,
-      charset: 'utf8',
-      declaration: true,
-      experimentalDecorators: true,
-      inlineSourceMap: true,
-      inlineSources: true,
-      lib: [ 'es2018' ],
-      module: 'CommonJS',
-      noEmitOnError: true,
-      noFallthroughCasesInSwitch: true,
-      noImplicitAny: true,
-      noImplicitReturns: true,
-      noImplicitThis: true,
-      noUnusedLocals: true,
-      noUnusedParameters: true,
-      resolveJsonModule: true,
-      strict: true,
-      strictNullChecks: true,
-      strictPropertyInitialization: true,
-      stripInternal: true,
-      target: 'ES2018',
-      ...options.compilerOptions,
-    };
+    this.compilerOptions = options.compilerOptions;
 
     new JsonFile(project, fileName, {
       obj: {

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -55,7 +55,7 @@ export interface TypeScriptLibraryProjectOptions extends NodeProjectOptions {
   /**
    * Docs directory
    * 
-   * @default 'API'
+   * @default 'docs'
    */
   readonly docsDirectory?: string;
 
@@ -63,7 +63,7 @@ export interface TypeScriptLibraryProjectOptions extends NodeProjectOptions {
    * Custom TSConfig
    * 
    */
-  readonly tsconfigOptions?: TypescriptConfigOptions;
+  readonly tsconfig?: TypescriptConfigOptions;
 }
 
 export class TypeScriptLibraryProject extends NodeProject {
@@ -74,7 +74,7 @@ export class TypeScriptLibraryProject extends NodeProject {
     super(options);
     
     this.docgen = options.docgen;
-    this.docsDirectory = options.docsDirectory || 'API/';
+    this.docsDirectory = options.docsDirectory || 'docs/';
 
     this.addScripts({
       compile: 'tsc',
@@ -108,7 +108,7 @@ export class TypeScriptLibraryProject extends NodeProject {
         stripInternal: true,
         target: 'ES2018',
       },
-      ...options.tsconfigOptions,
+      ...options.tsconfig,
     });
 
     this.gitignore.comment('exclude typescript compiler outputs');
@@ -169,10 +169,10 @@ export interface TypescriptConfigOptions {
    *
    * @default - see above
    */
-  readonly compilerOptions: TypescriptConfigCompilerOptions;
+  readonly compilerOptions: TypeScriptCompilerOptions;
 }
 
-export interface TypescriptConfigCompilerOptions {
+export interface TypeScriptCompilerOptions {
   /**
    * Ensures that your files are parsed in the ECMAScript strict mode, and emit “use strict”
    * for each source file.
@@ -343,7 +343,7 @@ export interface TypescriptConfigCompilerOptions {
 }
 
 export class TypescriptConfig extends Construct {
-  public readonly compilerOptions: TypescriptConfigCompilerOptions;
+  public readonly compilerOptions: TypeScriptCompilerOptions;
   public readonly include: string[];
   public readonly exclude: string[];
   public readonly fileName: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -41,7 +41,7 @@ export class Version extends Construct {
     const versionFile = `${this.project.outdir}/${VERSION_FILE}`;
     if (!fs.existsSync(versionFile)) {
       if (!fs.existsSync(this.project.outdir)) {
-        fs.mkdirSync(this.project.outdir);
+        fs.mkdirSync(this.project.outdir, { recursive: true });
       }
       fs.writeFileSync(versionFile, JSON.stringify({ version: '0.0.0' }));
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -41,7 +41,7 @@ export class Version extends Construct {
     const versionFile = `${this.project.outdir}/${VERSION_FILE}`;
     if (!fs.existsSync(versionFile)) {
       if (!fs.existsSync(this.project.outdir)) {
-        fs.mkdirSync(this.project.outdir, { recursive: true });
+        fs.mkdirpSync(this.project.outdir);
       }
       fs.writeFileSync(versionFile, JSON.stringify({ version: '0.0.0' }));
     }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "charset": "utf8",
     "declaration": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
*Description of changes:*
- Simple docgen via typedoc for TS projects
- Refactored the jsii-specific `tsconfig.jest.json` settings to live inside `jsii-project`
- compilerOptions interface
- `charset` is [deprecated](https://www.typescriptlang.org/tsconfig#charset)
- fix for the `mkdirSync` fix (now recursive)

BREAKING CHANGE: `options` is now required for `TypescriptConfig`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
