### PR TITLE
Allow using default bootstrap steps in 3rd party projects

### DIFF
--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -780,7 +780,7 @@ export interface PeerDependencyOptions {
   readonly pinnedDevDependency?: boolean;
 }
 
-const DEFAULT_WORKFLOW_BOOTSTRAP = [
+export const DEFAULT_WORKFLOW_BOOTSTRAP = [
   { run: `npx projen@${PROJEN_VERSION}` },
   { run: 'yarn install --frozen-lockfile' },
 ];


### PR DESCRIPTION
Usually copy and paste would be good enough, but since this sets the explicit
projen version, it's probably the easiest to make the `DEFAULT_WORKFLOW_BOOTSTRAP`
accessible in other contexts as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
