### PR TITLE
fix(typescript): Add missing `/` to default types path 

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -167,7 +167,7 @@ export class TypeScriptProject extends NodeProject {
       });
     }
 
-    this.manifest.types = options.entrypointTypes ?? `${path.dirname(this.entrypoint)}${path.basename(this.entrypoint, '.js')}.d.ts`;
+    this.manifest.types = options.entrypointTypes ?? `${path.dirname(this.entrypoint)}/${path.basename(this.entrypoint, '.js')}.d.ts`;
 
     const compilerOptions = {
       alwaysStrict: true,

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -167,7 +167,7 @@ export class TypeScriptProject extends NodeProject {
       });
     }
 
-    this.manifest.types = options.entrypointTypes ?? `${path.dirname(this.entrypoint)}/${path.basename(this.entrypoint, '.js')}.d.ts`;
+    this.manifest.types = options.entrypointTypes ?? `${path.join(path.dirname(this.entrypoint), path.basename(this.entrypoint, '.js'))}.d.ts`;
 
     const compilerOptions = {
       alwaysStrict: true,


### PR DESCRIPTION
*Issue #132, if available:*

*Description of changes:*
This adds the missing `/` in the default `types` path in `TypeScriptProject`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
