### PR TITLE
fix: eslint fails in nested projects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "jest": true,
     "node": true
   },
+  "root": true,
   "plugins": [
     "@typescript-eslint",
     "import"

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -178,6 +178,7 @@ export class Eslint extends Component {
         jest: true,
         node: true,
       },
+      root: true,
       plugins: [
         '@typescript-eslint',
         'import',


### PR DESCRIPTION
For nested projects eslint fails because it parses all parent configs too.
By setting the root flag, eslint stops looking in parent directories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
