### PR TITLE
fix: start menu does not respect package manager

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -36,7 +36,7 @@ const project = new JsiiProject({
 });
 
 // since this is projen, we need to compile before running projen, dah!
-project.addScript('projen', 'yarn compile', 'node .projenrc.js');
+project.addScript('projen', 'yarn compile && node .projenrc.js');
 
 project.gitignore.include('templates/**');
 

--- a/API.md
+++ b/API.md
@@ -73,6 +73,7 @@ Name|Description
 [NodeProjectOptions](#projen-nodeprojectoptions)|*No description*
 [PeerDependencyOptions](#projen-peerdependencyoptions)|*No description*
 [Rule](#projen-rule)|A Make rule.
+[ScriptOptions](#projen-scriptoptions)|Options for adding scripts.
 [StartEntryOptions](#projen-startentryoptions)|*No description*
 [StartOptions](#projen-startoptions)|*No description*
 [TomlFileOptions](#projen-tomlfileoptions)|*No description*
@@ -2047,16 +2048,19 @@ addPeerDeps(...deps: string[]): void
 
 
 
-#### addScript(name, ...commands)🔹 <a id="projen-nodeproject-addscript"></a>
+#### addScript(name, command, options?)🔹 <a id="projen-nodeproject-addscript"></a>
 
 Replaces the contents of an npm package.json script.
 
 ```ts
-addScript(name: string, ...commands: string[]): void
+addScript(name: string, command: string, options?: ScriptOptions): void
 ```
 
 * **name** (<code>string</code>)  The script name.
-* **commands** (<code>string</code>)  The commands to run (joined by "&&").
+* **command** (<code>string</code>)  The command to execute.
+* **options** (<code>[ScriptOptions](#projen-scriptoptions)</code>)  Options such as start menu description and category.
+  * **startCategory** (<code>[StartEntryCategory](#projen-startentrycategory)</code>)  Category in start menu. __*Default*__: StartEntryCategory.MISC
+  * **startDesc** (<code>string</code>)  Start menu description for this script. __*Default*__: no description
 
 
 
@@ -2364,6 +2368,7 @@ addEntry(name: string, options: StartEntryOptions): void
 
 * **name** (<code>string</code>)  The npm script name.
 * **options** (<code>[StartEntryOptions](#projen-startentryoptions)</code>)  Entry options.
+  * **command** (<code>string</code>)  The command to execute. 
   * **desc** (<code>string</code>)  The description of the start entry. 
   * **category** (<code>[StartEntryCategory](#projen-startentrycategory)</code>)  Priority-order (lower values will be shown first). __*Default*__: StartEntryCategory.MISC
 
@@ -3965,6 +3970,20 @@ Name | Type | Description
 
 
 
+## struct ScriptOptions 🔹 <a id="projen-scriptoptions"></a>
+
+
+Options for adding scripts.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**startCategory**?🔹 | <code>[StartEntryCategory](#projen-startentrycategory)</code> | Category in start menu.<br/>__*Default*__: StartEntryCategory.MISC
+**startDesc**?🔹 | <code>string</code> | Start menu description for this script.<br/>__*Default*__: no description
+
+
+
 ## struct StartEntryOptions 🔹 <a id="projen-startentryoptions"></a>
 
 
@@ -3974,6 +3993,7 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
+**command**🔹 | <code>string</code> | The command to execute.
 **desc**🔹 | <code>string</code> | The description of the start entry.
 **category**?🔹 | <code>[StartEntryCategory](#projen-startentrycategory)</code> | Priority-order (lower values will be shown first).<br/>__*Default*__: StartEntryCategory.MISC
 

--- a/package.json
+++ b/package.json
@@ -89,58 +89,72 @@
   "license": "Apache-2.0",
   "start": {
     "start": {
+      "command": "yarn run start",
       "desc": "Shows this menu"
     },
     "projen": {
       "desc": "Synthesize project configuration from .projenrc.js",
+      "command": "yarn run projen",
       "category": 3
     },
     "bump": {
       "desc": "Commits a bump to the package version based on conventional commits",
+      "command": "yarn run bump",
       "category": 2
     },
     "release": {
       "desc": "Bumps version & push to master",
+      "command": "yarn run release",
       "category": 2
     },
     "projen:upgrade": {
       "desc": "upgrades projen to the latest version",
+      "command": "yarn run projen:upgrade",
       "category": 3
     },
     "compile": {
       "desc": "Only compile",
+      "command": "yarn run compile",
       "category": 0
     },
     "watch": {
       "desc": "Watch & compile in the background",
+      "command": "yarn run watch",
       "category": 0
     },
     "build": {
       "desc": "Full release build (test+compile)",
+      "command": "yarn run build",
       "category": 0
     },
     "package": {
       "desc": "Create an npm tarball",
+      "command": "yarn run package",
       "category": 2
     },
     "test": {
       "desc": "Run tests",
+      "command": "yarn run test",
       "category": 1
     },
     "test:watch": {
       "desc": "Run jest in watch mode",
+      "command": "yarn run test:watch",
       "category": 1
     },
     "eslint": {
       "desc": "Runs eslint against the codebase",
+      "command": "yarn run eslint",
       "category": 1
     },
     "compat": {
       "desc": "Perform API compatibility check against latest version",
+      "command": "yarn run compat",
       "category": 2
     },
     "docgen": {
       "desc": "Generate API.md from .jsii manifest",
+      "command": "yarn run docgen",
       "category": 2
     }
   },

--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -113,23 +113,19 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
     this.addCdkDependency(...options.cdkDependencies ?? []);
 
     this.addScript('cdk', 'cdk');
-    this.addScript('synth', 'cdk synth');
-    this.addScript('deploy', 'cdk deploy');
+    this.addScript('synth', 'cdk synth', {
+      startDesc: 'Synthesizes your cdk app into cdk.out (part of "yarn build")',
+      startCategory: StartEntryCategory.BUILD,
+    });
+    this.addScript('deploy', 'cdk deploy', {
+      startDesc: 'Deploys your cdk app to the AWS cloud',
+      startCategory: StartEntryCategory.RELEASE,
+    });
     this.addScript('diff', 'cdk diff');
 
     this.addScript('compile', 'true');
     this.removeScript('watch'); // because we use ts-node
     this.addBuildCommand(`${this.runScriptCommand} synth`);
-
-    this.start?.addEntry('synth', {
-      desc: 'Synthesizes your cdk app into cdk.out (part of "yarn build")',
-      category: StartEntryCategory.BUILD,
-    });
-
-    this.start?.addEntry('deploy', {
-      desc: 'Deploys your cdk app to the AWS cloud',
-      category: StartEntryCategory.RELEASE,
-    });
 
     this.cdkConfig = {
       app: `npx ts-node ${path.join(this.srcdir, this.appEntrypoint)}`,

--- a/src/cli/cmds/start-app.ts
+++ b/src/cli/cmds/start-app.ts
@@ -5,6 +5,7 @@ import * as chalk from 'chalk';
 import * as inquirer from 'inquirer';
 import { StartEntryCategory, StartEntryOptions } from '../../start';
 
+
 const EXIT_MARKER = '$exit';
 
 export async function showStartMenu() {

--- a/src/cli/cmds/start-app.ts
+++ b/src/cli/cmds/start-app.ts
@@ -5,7 +5,6 @@ import * as chalk from 'chalk';
 import * as inquirer from 'inquirer';
 import { StartEntryCategory, StartEntryOptions } from '../../start';
 
-
 const EXIT_MARKER = '$exit';
 
 export async function showStartMenu() {
@@ -24,11 +23,11 @@ export async function showStartMenu() {
     return;
   }
 
-  child_process.spawnSync('yarn', ['-s', command], { stdio: 'inherit' });
+  child_process.spawnSync(command, { stdio: 'inherit' });
 }
 
 export function printStartMenu() {
-  console.error(chalk.cyanBright.underline('Commands ("yarn run COMMAND"):'));
+  console.error(chalk.cyanBright.underline('Commands:'));
   for (const entry of renderChoices()) {
     if (entry.type === 'separator') {
       console.error(entry.line);
@@ -55,7 +54,7 @@ function renderChoices() {
     category = cat;
     result.push({
       name: `${k.padEnd(width)}   ${entry.desc}`,
-      value: k,
+      value: entry.command,
       short: entry.desc,
     });
   }

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -40,10 +40,9 @@ export class Eslint extends Component {
 
     const dirs = options.dirs;
 
-    project.addScript('eslint', `eslint --ext .ts --fix ${dirs.join(' ')}`);
-    project.start?.addEntry('eslint', {
-      desc: 'Runs eslint against the codebase',
-      category: StartEntryCategory.TEST,
+    project.addScript('eslint', `eslint --ext .ts --fix ${dirs.join(' ')}`, {
+      startDesc: 'Runs eslint against the codebase',
+      startCategory: StartEntryCategory.TEST,
     });
     project.addTestCommand(`${project.runScriptCommand} eslint`);
 

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -113,15 +113,12 @@ export class Jest {
 
     project.addTestCommand(`jest ${jestOpts.join(' ')}`);
 
-    project.addScripts({
-      'test:watch': 'jest --watch',
-      'test:update': 'jest --updateSnapshot',
+    project.addScript('test:watch', 'jest --watch', {
+      startDesc: 'Run jest in watch mode',
+      startCategory: StartEntryCategory.TEST,
     });
 
-    project.start?.addEntry('test:watch', {
-      desc: 'Run jest in watch mode',
-      category: StartEntryCategory.TEST,
-    });
+    project.addScript('test:update', 'jest --updateSnapshot');
 
     project.addFields({ jest: this.config });
 

--- a/src/jsii-docgen.ts
+++ b/src/jsii-docgen.ts
@@ -11,10 +11,9 @@ import { StartEntryCategory } from './start';
 export class JsiiDocgen {
   constructor(project: JsiiProject) {
     project.addDevDependencies({ 'jsii-docgen': Semver.caret('1.3.2') });
-    project.addScript('docgen', 'jsii-docgen');
-    project.start?.addEntry('docgen', {
-      desc: 'Generate API.md from .jsii manifest',
-      category: StartEntryCategory.RELEASE,
+    project.addScript('docgen', 'jsii-docgen', {
+      startDesc: 'Generate API.md from .jsii manifest',
+      startCategory: StartEntryCategory.RELEASE,
     });
     project.addCompileCommand('jsii-docgen');
     project.gitignore.include('/API.md');

--- a/src/jsii-project.ts
+++ b/src/jsii-project.ts
@@ -184,10 +184,9 @@ export class JsiiProject extends TypeScriptProject {
       this.addFields({ deprecated: true });
     }
 
-    this.addScript('compat', `npx jsii-diff npm:$(node -p "require(\'./package.json\').name") -k --ignore-file ${compatIgnore} || (echo "\nUNEXPECTED BREAKING CHANGES: add keys such as \'removed:constructs.Node.of\' to ${compatIgnore} to skip.\n" && exit 1)`);
-    this.start?.addEntry('compat', {
-      desc: 'Perform API compatibility check against latest version',
-      category: StartEntryCategory.RELEASE,
+    this.addScript('compat', `npx jsii-diff npm:$(node -p "require(\'./package.json\').name") -k --ignore-file ${compatIgnore} || (echo "\nUNEXPECTED BREAKING CHANGES: add keys such as \'removed:constructs.Node.of\' to ${compatIgnore} to skip.\n" && exit 1)`, {
+      startDesc: 'Perform API compatibility check against latest version',
+      startCategory: StartEntryCategory.RELEASE,
     });
 
     this.addScript('compile', `jsii ${jsiiFlags}`);

--- a/src/next.ts
+++ b/src/next.ts
@@ -184,28 +184,24 @@ export class NextComponent extends Component {
     }
 
     // NextJS CLI commands, see: https://nextjs.org/docs/api-reference/cli
-    project.addScript('dev', 'next dev');
-    project.start?.addEntry('dev', {
-      desc: 'Starts the Next.js application in development mode',
-      category: StartEntryCategory.BUILD,
+    project.addScript('dev', 'next dev', {
+      startDesc: 'Starts the Next.js application in development mode',
+      startCategory: StartEntryCategory.BUILD,
     });
 
-    project.addScript('build', 'next build');
-    project.start?.addEntry('build', {
-      desc: 'Creates an optimized production build of your Next.js application',
-      category: StartEntryCategory.BUILD,
+    project.addScript('build', 'next build', {
+      startDesc: 'Creates an optimized production build of your Next.js application',
+      startCategory: StartEntryCategory.BUILD,
     });
 
-    project.addScript('server', 'next start');
-    project.start?.addEntry('server', {
-      desc: 'Starts the Next.js application in production mode',
-      category: StartEntryCategory.RELEASE,
+    project.addScript('server', 'next start', {
+      startDesc: 'Starts the Next.js application in production mode',
+      startCategory: StartEntryCategory.RELEASE,
     });
 
-    project.addScript('telemetry', 'next telemetry');
-    project.start?.addEntry('telemetry', {
-      desc: 'Checks the status of Next.js telemetry collection',
-      category: StartEntryCategory.MISC,
+    project.addScript('telemetry', 'next telemetry', {
+      startDesc: 'Checks the status of Next.js telemetry collection',
+      startCategory: StartEntryCategory.MISC,
     });
 
     project.npmignore?.exclude('# Next.js', '/.next/');

--- a/src/projen-upgrade.ts
+++ b/src/projen-upgrade.ts
@@ -36,13 +36,9 @@ export class ProjenUpgrade {
   constructor(project: NodeProject, options: ProjenUpgradeOptions = { }) {
     const script = 'projen:upgrade';
 
-    project.addScript(script,
-      'yarn upgrade -L projen',
-      'CI="" yarn projen'); // if CI is defined, projen runs yarn with --frozen-lockfile
-
-    project.start?.addEntry(script, {
-      desc: 'upgrades projen to the latest version',
-      category: StartEntryCategory.MAINTAIN,
+    project.addScript(script, 'yarn upgrade -L projen && CI="" yarn projen', {
+      startDesc: 'upgrades projen to the latest version',
+      startCategory: StartEntryCategory.MAINTAIN,
     });
 
     if (options.autoUpgradeSecret) {

--- a/src/start.ts
+++ b/src/start.ts
@@ -14,7 +14,11 @@ export class Start extends Component {
     this.nodeProject = project;
 
     project.addScript('start', 'npx projen start -i');
+
+    // we have to explicitly add and not use `addScript` options since
+    // this `project.start` is undefined until we finish to initialize.
     this.addEntry('start', {
+      command: `${project.runScriptCommand} start`,
       desc: 'Shows this menu',
     });
   }
@@ -39,6 +43,11 @@ export interface StartEntryOptions {
    * The description of the start entry.
    */
   readonly desc: string;
+
+  /**
+   * The command to execute.
+   */
+  readonly command: string;
 
   /**
    * Priority-order (lower values will be shown first).

--- a/src/typescript-typedoc.ts
+++ b/src/typescript-typedoc.ts
@@ -1,17 +1,16 @@
 import { Semver } from './semver';
 import { StartEntryCategory } from './start';
-import { TypeScriptLibraryProject } from './typescript';
+import { TypeScriptProject } from './typescript';
 
 /**
   Adds a simple Typescript documentation generator
  */
 export class TypedocDocgen {
-  constructor(project: TypeScriptLibraryProject) {
+  constructor(project: TypeScriptProject) {
     project.addDevDependencies({ typedoc: Semver.caret('0.17.8') });
-    project.addScript('docgen', 'typedoc --out ' + project.docsDirectory);
-    project.start?.addEntry('docgen', {
-      desc: `Generate TypeScript API reference ${project.docsDirectory}`,
-      category: StartEntryCategory.RELEASE,
+    project.addScript('docgen', 'typedoc --out ' + project.docsDirectory, {
+      startDesc: `Generate TypeScript API reference ${project.docsDirectory}`,
+      startCategory: StartEntryCategory.RELEASE,
     });
   }
 }

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -129,15 +129,10 @@ export class TypeScriptProject extends NodeProject {
     this.docsDirectory = options.docsDirectory ?? 'docs/';
 
     this.addCompileCommand('tsc');
-    this.start?.addEntry('compile', {
-      desc: 'Only compile',
-      category: StartEntryCategory.BUILD,
-    });
 
-    this.addScript('watch', 'tsc -w');
-    this.start?.addEntry('watch', {
-      desc: 'Watch & compile in the background',
-      category: StartEntryCategory.BUILD,
+    this.addScript('watch', 'tsc -w', {
+      startDesc: 'Watch & compile in the background',
+      startCategory: StartEntryCategory.BUILD,
     });
 
     // by default, we first run tests (jest compiles the typescript in the background) and only then we compile.
@@ -148,25 +143,21 @@ export class TypeScriptProject extends NodeProject {
     } else {
       this.addBuildCommand(`${this.runScriptCommand} test`, `${this.runScriptCommand} compile`);
     }
-    this.start?.addEntry('build', {
-      desc: 'Full release build (test+compile)',
-      category: StartEntryCategory.BUILD,
-    });
 
     if (options.package ?? true) {
-      this.addScript('package',
+      const packageCommand = [
         'rm -fr dist',
         'mkdir -p dist/js',
         `${this.packageManager} pack`,
         'mv *.tgz dist/js/',
-      );
+      ].join(' && ');
+
+      this.addScript('package', packageCommand, {
+        startDesc: 'Create an npm tarball',
+        startCategory: StartEntryCategory.RELEASE,
+      });
 
       this.addBuildCommand(`${this.runScriptCommand} package`);
-
-      this.start?.addEntry('package', {
-        desc: 'Create an npm tarball',
-        category: StartEntryCategory.RELEASE,
-      });
     }
 
     if (options.entrypointTypes || this.entrypoint !== '') {
@@ -295,6 +286,13 @@ export class TypeScriptProject extends NodeProject {
    */
   public addBuildCommand(...commands: string[]) {
     this.addScriptCommand('build', ...commands);
+
+    this.start?.addEntry('build', {
+      desc: 'Full release build (test+compile)',
+      command: `${this.runScriptCommand} build`,
+      category: StartEntryCategory.BUILD,
+    });
+
   }
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -20,17 +20,14 @@ export class Version extends Component {
 
     project.addScript('no-changes', '(git log --oneline -1 | grep -q "chore(release):") && echo "No changes to release."');
 
-    project.addScript('bump', `${project.runScriptCommand} --silent no-changes || standard-version`);
-    project.addScript('release', `${project.runScriptCommand} --silent no-changes || (${project.runScriptCommand} bump && git push --follow-tags origin ${options.releaseBranch})`);
-
-    project.start?.addEntry('bump', {
-      desc: 'Commits a bump to the package version based on conventional commits',
-      category: StartEntryCategory.RELEASE,
+    project.addScript('bump', `${project.runScriptCommand} --silent no-changes || standard-version`, {
+      startDesc: 'Commits a bump to the package version based on conventional commits',
+      startCategory: StartEntryCategory.RELEASE,
     });
 
-    project.start?.addEntry('release', {
-      desc: `Bumps version & push to ${options.releaseBranch}`,
-      category: StartEntryCategory.RELEASE,
+    project.addScript('release', `${project.runScriptCommand} --silent no-changes || (${project.runScriptCommand} bump && git push --follow-tags origin ${options.releaseBranch})`, {
+      startDesc: `Bumps version & push to ${options.releaseBranch}`,
+      startCategory: StartEntryCategory.RELEASE,
     });
 
     project.addDevDependencies({


### PR DESCRIPTION
Add a `command` to each start menu entry in `package.json` and use it instead of assuming this is a yarn script. This opens the door for decoupling start menu from yarn/npm and allowing it to be used in other project types as an entry point.

This change also adds `ScriptOptions` to `node.addScript()` such that it is possible
to register a start menu entry together with adding scripts to the project.

Fixes #217

BREAKING CHANGE: `node.addScript(script, command)` now takes a single command instead of variable arguments. Use `node.addScript(script, [s1,s2].join(' && '))` to build a command from multiple statements.

